### PR TITLE
RunLoop and QueueWorker

### DIFF
--- a/src/tink/RunLoop.hx
+++ b/src/tink/RunLoop.hx
@@ -268,6 +268,7 @@ class RunLoop extends QueueWorker {
         var res = null;
         while (res != Aborted) 
           res = w.step();
+        this.asap(function() this.slaves.remove(w));
       });
     #end
     return w;

--- a/src/tink/runloop/QueueWorker.hx
+++ b/src/tink/runloop/QueueWorker.hx
@@ -50,7 +50,7 @@ class QueueWorker implements Worker {
   }
   
   public function kill()
-    tasks = null;
+    asap(function() { tasks = null; } );
   
   function error(e:Error, t:Task) 
     owner.asap(function () owner.onError(e, t, this, haxe.CallStack.exceptionStack()));

--- a/src/tink/runloop/QueueWorker.hx
+++ b/src/tink/runloop/QueueWorker.hx
@@ -50,7 +50,7 @@ class QueueWorker implements Worker {
   }
   
   public function kill()
-    asap(function() { tasks = null; } );
+    asap(function() tasks = null);
   
   function error(e:Error, t:Task) 
     owner.asap(function () owner.onError(e, t, this, haxe.CallStack.exceptionStack()));


### PR DESCRIPTION
Couple small one liners for RunLoop and QueueWorker.

The RunLoop.slaves array doesn't see use in concurrent mode, just a housekeeping patch.

The QueueWorker kill method should run on the runloop's thread so the worker created in RunLoop.createSlave can exit.  Otherwise in concurrent mode the worker hangs waiting for a task that can never arrive.
